### PR TITLE
Replace dot notation with bracket notation.

### DIFF
--- a/lib/chef/knife/depgraph.rb
+++ b/lib/chef/knife/depgraph.rb
@@ -64,8 +64,8 @@ class Chef
 
         solution.sort.each do |name, cb|
           dep_graph[name] = {
-            "version" => cb.version,
-            "deps" => cb.metadata.dependencies
+            "version" => cb['version'],
+            "deps" => cb['metadata']['dependencies']
           }
         end
 


### PR DESCRIPTION
On recent versions of ChefDK, the dot notation has been deprecated and causes a failing error. This resolves that issue.